### PR TITLE
android config

### DIFF
--- a/scripts/jenkins/mobile/mobile-functional-tests-android.sh
+++ b/scripts/jenkins/mobile/mobile-functional-tests-android.sh
@@ -93,6 +93,7 @@ killall LiteServ || true
 
 echo ============================================ npm test
 export TAP_TIMEOUT=20000
+export CONF_FILE=local_android
 npm test 2>&1 | tee  ${WORKSPACE}/npm_test_results.log
 
 echo ============================================ killing any hanging LiteServ


### PR DESCRIPTION
This should cause it to launch an emulator on port 8080, using "adb" the launching code is here, triggered by the use of the local_android.js config file: https://github.com/couchbaselabs/cblite-tests/blob/master/tests/common.js#L71

And the adb invocation: https://github.com/couchbaselabs/cblite-tests/blob/master/lib/launcher.js#L61

I don't know if this will get the android tests to run automatically, but I think it's the next step.
