### PR TITLE
Do not use relative path for shared objects

### DIFF
--- a/scripts/jenkins/sdk/php_unit_test.sh
+++ b/scripts/jenkins/sdk/php_unit_test.sh
@@ -15,4 +15,4 @@ ulimit -c unlimited
 /sbin/sysctl kernel.core_pattern || /usr/sbin/sysctl kernel.core_pattern || sysctl kernel.core_pattern
 
 # Test
-CPDSN=${NODE_IP} ${PHP_DIR}/bin/php -d extension=phar.so -d extension=./modules/couchbase.so ${PHP_DIR}/phpunit.phar tests/
+CPDSN=${NODE_IP} ${PHP_DIR}/bin/php -d extension=phar.so -d extension=$(pwd)/modules/couchbase.so ${PHP_DIR}/phpunit.phar tests/


### PR DESCRIPTION
They gets skipped by debugger later

/cc @hkodungallur 