### PR TITLE
CBD-6003, add proxy.golang.org to GOPROXY

### DIFF
--- a/scripts/jenkins/mobile/sgw_unix_build.sh
+++ b/scripts/jenkins/mobile/sgw_unix_build.sh
@@ -307,7 +307,7 @@ fi
 export CGO_ENABLED=1
 
 export GOPATH=`pwd`/godeps \
-GOPROXY=http://goproxy.build.couchbase.com \
+GOPROXY=http://goproxy.build.couchbase.com,https://proxy.golang.org \
 GOPRIVATE=github.com/couchbaselabs/go-fleecedelta \
 
 go_build

--- a/scripts/jenkins/mobile/sgw_windows_build.bat
+++ b/scripts/jenkins/mobile/sgw_windows_build.bat
@@ -186,7 +186,7 @@ echo GOOS=%GOOS% GOARCH=%GOARCH% GOPATH=%GOPATH%
 if "%GO_MOD_BUILD%" == "false" (
     set GO111MODULE=off
 )
-set GOPROXY=http://goproxy.build.couchbase.com
+set GOPROXY=http://goproxy.build.couchbase.com,https://proxy.golang.org
 set GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
 pushd %SGW_DIR%
 go install %GO_EDITION_OPTION% .\...


### PR DESCRIPTION
Add proxy.golang.org to GOPROXY as a fallback in case Athens can't handle an module.

-Ming